### PR TITLE
TomatoCart_Version_1.1.8.6.1

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,8 +5,8 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="1.1.8.5"
-URL="http://sourceforge.net/projects/tomatocart/files/TomatoCart-v${VERSION}.zip"
+VERSION="1.1.8.6.1"
+URL="http://sourceforge.net/projects/tomatocart/files/TomatoCart-${VERSION}.zip"
 
 dl $URL /usr/local/src
 


### PR DESCRIPTION
Changed the version of TomatoCart to 1.1.8.6.1.
